### PR TITLE
Update sbt to version 1.2.7

### DIFF
--- a/sbt.nuspec
+++ b/sbt.nuspec
@@ -3,9 +3,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>sbt</id>
-        <version>1.2.1.17082018</version>
+        <version>1.2.7</version>
         <title>sbt</title>
-        <authors>Steven Blundy,Josh Cough,Mark Harrah,Stuart Roebuck,Tony Sloane,Vesa Vilhonen,Jason Zaugg,Jordi Garcia</authors>
+        <authors>Steven Blundy,Josh Cough,Mark Harrah,Stuart Roebuck,Tony Sloane,Vesa Vilhonen,Jason Zaugg,Jordi Garcia,Anthony Accioly</authors>
         <owners>ssteward54</owners>
         <licenseUrl>https://github.com/sbt/sbt/blob/1.x/LICENSE</licenseUrl>
         <projectUrl>http://www.scala-sbt.org/</projectUrl>
@@ -22,10 +22,10 @@
         <docsUrl>http://www.scala-sbt.org/1.x/docs/index.html</docsUrl>
         <releaseNotes># Release Notes
 
-- Updated to version 1.2.1 with uninstall before install
+- Updated to version 1.2.7
 
 ### Version
-1.2.1
+1.2.7
         </releaseNotes>
     </metadata>
 	<files>

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -11,7 +11,7 @@ if ($installerType -ne 'MSI') {
 }
 
 $toolsDir    = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url         = 'https://github.com/sbt/sbt/releases/download/v1.2.1/sbt-1.2.1.msi'
+$url         = 'https://piccolo.link/sbt-1.2.7.msi'
 $url64       = ''
 
 $packageArgs = @{
@@ -23,7 +23,7 @@ $packageArgs = @{
 
   softwareName   = 'sbt*'
 
-  checksum       = '7F2B0450EAB084DCD1104CD6CE6B6A884DB5F994F237AA62BBC6598C727AF174'
+  checksum       = 'A7CD589331F43D4E4EEEFEE92A6FB8675DA34FD5ABAD7EC41EE90E61FECBEFB6'
   checksumType   = 'sha256'
   checksum64     = ''
   checksumType64 = 'sha256'


### PR DESCRIPTION
The shortened URL controled by sbt maintainers (https://www.scala-sbt.org/download.html).
Download was faster than GitHub for me.
